### PR TITLE
Making groute is able to run on Volta cards

### DIFF
--- a/include/groute/cta_work.h
+++ b/include/groute/cta_work.h
@@ -183,7 +183,7 @@ namespace dev {
 #endif
             const int lane_id = cub::LaneId();
 
-            while (__any_sync(0xffffffff, np_local.size >= NP_WP_CROSSOVER))
+            while (__any_sync(__activemask(), np_local.size >= NP_WP_CROSSOVER))
             {
 
 #ifndef NO_CTA_WARP_INTRINSICS

--- a/include/groute/cta_work.h
+++ b/include/groute/cta_work.h
@@ -183,19 +183,19 @@ namespace dev {
 #endif
             const int lane_id = cub::LaneId();
 
-            while (__any(np_local.size >= NP_WP_CROSSOVER))
+            while (__any_sync(0xffffffff, np_local.size >= NP_WP_CROSSOVER))
             {
 
 #ifndef NO_CTA_WARP_INTRINSICS
                 // Compete for work scheduling  
-                int mask = __ballot(np_local.size >= NP_WP_CROSSOVER ? 1 : 0); 
+                int mask = __ballot_sync(__activemask(), np_local.size >= NP_WP_CROSSOVER ? 1 : 0);
                 // Select a deterministic winner  
                 int leader = __ffs(mask) - 1;   
 
                 // Broadcast data from the leader  
-                index_type start = cub::ShuffleIndex(np_local.start, leader);
-                index_type size = cub::ShuffleIndex(np_local.size, leader);
-                TMetaData meta_data = cub::ShuffleIndex(np_local.meta_data, leader);
+                index_type start = cub::ShuffleIndex<32>(np_local.start, leader, __activemask());
+                index_type size = cub::ShuffleIndex<32>(np_local.size, leader, __activemask());
+                TMetaData meta_data = cub::ShuffleIndex<32>(np_local.meta_data, leader, __activemask());
 
                 if (leader == lane_id)
                 {

--- a/include/groute/distributed_worklist.h
+++ b/include/groute/distributed_worklist.h
@@ -128,9 +128,9 @@ namespace groute {
 
             if (WarpAppend)
             {
-                int filter_mask = __ballot(flags == SF_None ? 1 : 0);
-                int take_mask = __ballot(flags & SF_Take ? 1 : 0);
-                int pass_mask = __ballot(flags & SF_Pass ? 1 : 0);
+                int filter_mask = __ballot_sync(__activemask(), flags == SF_None ? 1 : 0);
+                int take_mask = __ballot_sync(__activemask(), flags & SF_Take ? 1 : 0);
+                int pass_mask = __ballot_sync(__activemask(), flags & SF_Pass ? 1 : 0);
                     // never inline the masks into the conditional branching below  
                     // although it may work. The compiler should optimize this anyhow, 
                     // but this avoids him from unifying the __ballot's 

--- a/include/groute/fused_distributed_worklist.h
+++ b/include/groute/fused_distributed_worklist.h
@@ -149,9 +149,9 @@ namespace groute {
                 TRemote work = work_ptr[tid];
                 SplitFlags flags = split_ops.on_receive(work);
 
-                int filter_mask = __ballot(flags == SF_None ? 1 : 0);
-                int take_mask = __ballot(flags & SF_Take ? 1 : 0);
-                int pass_mask = __ballot(flags & SF_Pass ? 1 : 0);
+                int filter_mask = __ballot_sync(__activemask(), flags == SF_None ? 1 : 0);
+                int take_mask = __ballot_sync(__activemask(), flags & SF_Take ? 1 : 0);
+                int pass_mask = __ballot_sync(__activemask(), flags & SF_Pass ? 1 : 0);
                 // never inline the masks into the conditional branching below  
                 // although it may work. The compiler should optimize this anyhow, 
                 // but this avoids it from unifying the __ballot's 

--- a/include/groute/fused_worker.h
+++ b/include/groute/fused_worker.h
@@ -96,8 +96,8 @@ namespace groute
 
             bool is_high_prio = ops.is_high_prio(work, global_priority);
 
-            int high_mask = __ballot(is_high_prio ? 1 : 0);
-            int low_mask = __ballot(is_high_prio ? 0 : 1);
+            int high_mask = __ballot_sync(__activemask(), is_high_prio ? 1 : 0);
+            int low_mask = __ballot_sync(__activemask(), is_high_prio ? 0 : 1);
 
             if (is_high_prio)
             {

--- a/samples/bfs/bfs_async_opt.cu
+++ b/samples/bfs/bfs_async_opt.cu
@@ -123,8 +123,8 @@ namespace bfs {
 
                                 // TODO: move ballot logic to a device structure   
 
-                                int owned_mask = __ballot(is_owned ? 1 : 0);
-                                int remote_mask = __ballot(is_owned ? 0 : 1);
+                                int owned_mask = __ballot_sync(__activemask(), is_owned ? 1 : 0);
+                                int remote_mask = __ballot_sync(__activemask(), is_owned ? 0 : 1);
 
                                 if (is_owned)
                                 {
@@ -177,8 +177,8 @@ namespace bfs {
 
                             // TODO: move ballot logic to a device structure   
 
-                            int owned_mask = __ballot(is_owned ? 1 : 0);
-                            int remote_mask = __ballot(is_owned ? 0 : 1);
+                            int owned_mask = __ballot_sync(__activemask(), is_owned ? 1 : 0);
+                            int remote_mask = __ballot_sync(__activemask(), is_owned ? 0 : 1);
 
                             if (is_owned)
                             {

--- a/samples/sssp/sssp_async.cu
+++ b/samples/sssp/sssp_async.cu
@@ -255,8 +255,8 @@ namespace sssp
                     {
                         if (graph.owns(dest))
                         {
-                            int near_mask = __ballot(distance + weight <= delta ? 1 : 0);
-                            int far_mask = __ballot(distance + weight <= delta ? 0 : 1);
+                            int near_mask = __ballot_sync(__activemask(), distance + weight <= delta ? 1 : 0);
+                            int far_mask = __ballot_sync(__activemask(), distance + weight <= delta ? 0 : 1);
 
                             if (distance + weight <= delta)
                             {
@@ -312,8 +312,8 @@ namespace sssp
                 {
                     if (graph.owns(dest))
                     {
-                        int near_mask = __ballot(distance + weight <= delta ? 1 : 0);
-                        int far_mask = __ballot(distance + weight <= delta ? 0 : 1);
+                        int near_mask = __ballot_sync(__activemask(), distance + weight <= delta ? 1 : 0);
+                        int far_mask = __ballot_sync(__activemask(), distance + weight <= delta ? 0 : 1);
 
                         if (distance + weight <= delta)
                         {
@@ -353,8 +353,8 @@ namespace sssp
             index_t node = work_source.get_work(tid);
             distance_t distance = node_distances.get_item(node);
 
-            int near_mask = __ballot(distance <= delta ? 1 : 0);
-            int far_mask = __ballot(distance <= delta ? 0 : 1);
+            int near_mask = __ballot_sync(__activemask(), distance <= delta ? 1 : 0);
+            int far_mask = __ballot_sync(__activemask(), distance <= delta ? 0 : 1);
 
             if (distance <= delta)
             {

--- a/samples/sssp/sssp_async_opt.cu
+++ b/samples/sssp/sssp_async_opt.cu
@@ -122,8 +122,8 @@ namespace sssp {
 
                                 // TODO: move ballot logic to a device structure   
                                 
-                                int owned_mask = __ballot(is_owned ? 1 : 0);
-                                int remote_mask = __ballot(is_owned ? 0 : 1);
+                                int owned_mask = __ballot_sync(__activemask(), is_owned ? 1 : 0);
+                                int remote_mask = __ballot_sync(__activemask(), is_owned ? 0 : 1);
 
                                 if (is_owned)
                                 {
@@ -179,8 +179,8 @@ namespace sssp {
 
                             // TODO: move ballot logic to a device structure 
 
-                            int owned_mask = __ballot(is_owned ? 1 : 0);
-                            int remote_mask = __ballot(is_owned ? 0 : 1);
+                            int owned_mask = __ballot_sync(__activemask(), is_owned ? 1 : 0);
+                            int remote_mask = __ballot_sync(__activemask(), is_owned ? 0 : 1);
 
                             if (is_owned)
                             {


### PR DESCRIPTION
I have tested BFS, SSSP, PR, and CC after these changes are made, and groute produces correct answers.

```
root@dlc16rw6bkgr8yxf-worker-0:~/data/liang/libgrape-lite# nvidia-smi
Fri May  7 07:59:39 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 440.64       Driver Version: 440.64       CUDA Version: 11.2     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  Tesla V100-SXM2...  On   | 00000000:B1:00.0 Off |                    0 |
| N/A   39C    P0    67W / 300W |  29445MiB / 32510MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   1  Tesla V100-SXM2...  On   | 00000000:B2:00.0 Off |                    0 |
| N/A   39C    P0    70W / 300W |  29463MiB / 32510MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   2  Tesla V100-SXM2...  On   | 00000000:DB:00.0 Off |                    0 |
| N/A   35C    P0    68W / 300W |  29483MiB / 32510MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   3  Tesla V100-SXM2...  On   | 00000000:DC:00.0 Off |                    0 |
| N/A   36C    P0    42W / 300W |     12MiB / 32510MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                       GPU Memory |
|  GPU       PID   Type   Process name                             Usage      |
|=============================================================================|
+-----------------------------------------------------------------------------+
```



BFS:
```
root@dlc16rw6bkgr8yxf-worker-0:~/data/liang/groute/build# ./bfs -graphfile ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr -source_node=1 -check -num_gpus=4
Running BFS with 4 GPUs, starting with 1 GPUs

Testing single GPU BFS
--------------------

Testing with 1 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)
../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr has 4847571 nodes and 136653880 edges
read 136653880 edges
read data for 136653880 edges

----- Running BFS -----


BFS: 26.904000 ms. <filter>

Testing with 2 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running BFS -----


BFS: 21.553000 ms. <filter>

Testing with 3 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running BFS -----


BFS: 21.784000 ms. <filter>

Testing with 4 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running BFS -----


BFS: 25.032000 ms. <filter>

Overall: Test passed
```

SSSP:
```
root@dlc16rw6bkgr8yxf-worker-0:~/data/liang/groute/build# ./sssp -graphfile ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr -source_node=1 -check -num_gpus=4
Running SSSP with 4 GPUs, starting with 1 GPUs

Testing single GPU SSSP
--------------------

Testing with 1 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)
../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr has 4847571 nodes and 136653880 edges
read 136653880 edges
read data for 136653880 edges

----- Running SSSP -----


SSSP: 91.963000 ms. <filter>

Testing with 2 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running SSSP -----


SSSP: 81.174000 ms. <filter>

Testing with 3 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running SSSP -----


SSSP: 77.355000 ms. <filter>

Testing with 4 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running SSSP -----


SSSP: 83.101000 ms. <filter>

Overall: Test passed
```

PR:
```
root@dlc16rw6bkgr8yxf-worker-0:~/data/liang/groute/build# ./pr -graphfile ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr -check -num_gpus=4
Running Page Rank with 4 GPUs, starting with 1 GPUs

Testing single GPU Page Rank
--------------------

Testing with 1 GPUs
--------------------
                                                                                                                                                                                                                                                                                   [0/1969]

Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)
../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr has 4847571 nodes and 136653880 edges
read 136653880 edges
read data for 136653880 edges

----- Running PR -----


PR: 442.786000 ms. <filter>


SUMMARY: 0/10 large differences, 0/10 node diffs, total mean diff: 0.555107

Testing with 2 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running PR -----


PR: 1087.103000 ms. <filter>


SUMMARY: 0/10 large differences, 0/10 node diffs, total mean diff: 0.272227

Testing with 3 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running PR -----


PR: 3120.713000 ms. <filter>


SUMMARY: 0/10 large differences, 0/10 node diffs, total mean diff: 0.427039

Testing with 4 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running PR -----


PR: 4306.547000 ms. <filter>


SUMMARY: 0/10 large differences, 0/10 node diffs, total mean diff: 0.616336

Overall: Test passed
```

CC:
```
root@dlc16rw6bkgr8yxf-worker-0:~/data/liang/groute/build# ./cc -graphfile ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr  -num_gpus=4
Running CC with 4 GPUs, starting with 1 GPUs
Testing with 1 GPUs
--------------------
                                                                                                                                                                                                                                                                                   [0/1833]

Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)
../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr has 4847571 nodes and 136653880 edges
read 136653880 edges
read data for 136653880 edges

----- Running CC Async -----


CC (Async): 6.272000 ms. <filter>


Components: 1876

Testing with 2 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running CC Async -----


CC (Async): 5.255000 ms. <filter>


Components: 1876

Testing with 3 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running CC Async -----


CC (Async): 5.063000 ms. <filter>


Components: 1876

Testing with 4 GPUs
--------------------


Loading graph ../../new_dataset/soc-LiveJournal1/soc-LiveJournal1.ud.random.weight.gr (1)

----- Running CC Async -----


CC (Async): 7.684000 ms. <filter>


Components: 1876

Overall: Test passed
```